### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # example-smart-on-fhir-app
 A barebones SMART on FHIR application for testing purposes
 
-See: https://canvas-medical.github.io/example-smart-on-fhir-app/
+Intended for use with the Canvas Guide to [Embedding a SMART app into Canvas](https://docs.canvasmedical.com/guides/embedding-a-smart-on-fhir-application/)
+
+Hosted via Github pages at: https://canvas-medical.github.io/example-smart-on-fhir-app/


### PR DESCRIPTION
This PR adds a link back to the [SMART on FHIR guide](https://docs.canvasmedical.com/guides/embedding-a-smart-on-fhir-application/) to the README for easier navigation.